### PR TITLE
Breaking: take in custom formatter option

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,6 +1,6 @@
 var bench = require('fastbench')
 var utilFormat = require('util').format
-var quickFormat = require('./')
+var quickFormat = require('./')()
 
 var run = bench([
   function util(cb) {

--- a/index.js
+++ b/index.js
@@ -1,109 +1,137 @@
 'use strict'
-function tryStringify (o) {
-  try { return JSON.stringify(o) } catch(e) { return '"[Circular]"' }
+function tryStringify(o) {
+  try {
+    return JSON.stringify(o)
+  } catch (e) {
+    return '"[Circular]"'
+  }
 }
 
-module.exports = format
+const CHAR_PERCENT = '%'.charCodeAt(0)
+const CHAR_s = 's'.charCodeAt(0)
+const CHAR_d = 'd'.charCodeAt(0)
+const CHAR_f = 'f'.charCodeAt(0)
+const CHAR_i = 'i'.charCodeAt(0)
+const CHAR_O = 'O'.charCodeAt(0)
+const CHAR_o = 'o'.charCodeAt(0)
+const CHAR_j = 'j'.charCodeAt(0)
 
-function format(f, args, opts) {
-  var ss = (opts && opts.stringify) || tryStringify
-  var offset = 1
-  if (typeof f === 'object' && f !== null) {
-    var len = args.length + offset
-    if (len === 1) return f
-    var objects = new Array(len)
-    objects[0] = ss(f)
-    for (var index = 1; index < len; index++) {
-      objects[index] = ss(args[index])
-    }
-    return objects.join(' ')
-  }
-  if (typeof f !== 'string') {
-    return f
-  }
-  var argLen = args.length
-  if (argLen === 0) return f
-  var str = ''
-  var a = 1 - offset
-  var lastPos = -1
-  var flen = (f && f.length) || 0
-  for (var i = 0; i < flen;) {
-    if (f.charCodeAt(i) === 37 && i + 1 < flen) {
-      lastPos = lastPos > -1 ? lastPos : 0
-      switch (f.charCodeAt(i + 1)) {
-        case 100: // 'd'
-        case 102: // 'f'
-          if (a >= argLen)
-            break
-          if (args[a] == null)  break
-          if (lastPos < i)
-            str += f.slice(lastPos, i)
-          str += Number(args[a])
-          lastPos = i + 2
-          i++
-          break
-        case 105: // 'i'
-          if (a >= argLen)
-            break
-          if (args[a] == null)  break
-          if (lastPos < i)
-            str += f.slice(lastPos, i)
-          str += Math.floor(Number(args[a]))
-          lastPos = i + 2
-          i++
-          break
-        case 79: // 'O'
-        case 111: // 'o'
-        case 106: // 'j'
-          if (a >= argLen)
-            break
-          if (args[a] === undefined) break
-          if (lastPos < i)
-            str += f.slice(lastPos, i)
-          var type = typeof args[a]
-          if (type === 'string') {
-            str += '\'' + args[a] + '\''
-            lastPos = i + 2
-            i++
-            break
-          }
-          if (type === 'function') {
-            str += args[a].name || '<anonymous>'
-            lastPos = i + 2
-            i++
-            break
-          }
-          str += ss(args[a])
-          lastPos = i + 2
-          i++
-          break
-        case 115: // 's'
-          if (a >= argLen)
-            break
-          if (lastPos < i)
-            str += f.slice(lastPos, i)
-          str += String(args[a])
-          lastPos = i + 2
-          i++
-          break
-        case 37: // '%'
-          if (lastPos < i)
-            str += f.slice(lastPos, i)
-          str += '%'
-          lastPos = i + 2
-          i++
-          a--
-          break
+module.exports = function build(opts) {
+  // Keep (custom) formatters in a map for easy lookup
+  const formatters = {}
+
+  Object.keys((opts || {}).formatters || {}).forEach(key => {
+    // For now, only support single character keys
+    if (key.length > 1)
+      throw new Error(`Formatter %${key} has more than one character`)
+    if (typeof opts.formatters[key] !== 'function')
+      throw new Error(`Formatter for %${key} is not a function`)
+
+    const c = key.charCodeAt(0)
+    formatters[c] = opts.formatters[key]
+  })
+
+  function format(f, args, opts) {
+    var ss = (opts && opts.stringify) || tryStringify
+    var offset = 1
+    if (typeof f === 'object' && f !== null) {
+      var len = args.length + offset
+      if (len === 1) return f
+      var objects = new Array(len)
+      objects[0] = ss(f)
+      for (var index = 1; index < len; index++) {
+        objects[index] = ss(args[index])
       }
-      ++a
+      return objects.join(' ')
     }
-    ++i
-  }
-  if (lastPos === -1)
-    return f
-  else if (lastPos < flen) {
-    str += f.slice(lastPos)
+    if (typeof f !== 'string') {
+      return f
+    }
+    var argLen = args.length
+    if (argLen === 0) return f
+    var str = ''
+    var a = 1 - offset
+    var lastPos = -1
+    var flen = (f && f.length) || 0
+    for (var i = 0; i < flen; ) {
+      if (f.charCodeAt(i) === CHAR_PERCENT && i + 1 < flen) {
+        lastPos = lastPos > -1 ? lastPos : 0
+        const c = f.charCodeAt(i + 1)
+        switch (c) {
+          case CHAR_d:
+          case CHAR_f:
+            if (a >= argLen) break
+            if (args[a] == null) break
+            if (lastPos < i) str += f.slice(lastPos, i)
+            str += Number(args[a])
+            lastPos = i + 2
+            i++
+            break
+          case CHAR_i:
+            if (a >= argLen) break
+            if (args[a] == null) break
+            if (lastPos < i) str += f.slice(lastPos, i)
+            str += Math.floor(Number(args[a]))
+            lastPos = i + 2
+            i++
+            break
+          case CHAR_O:
+          case CHAR_o:
+          case CHAR_j:
+            if (a >= argLen) break
+            if (args[a] === undefined) break
+            if (lastPos < i) str += f.slice(lastPos, i)
+            var type = typeof args[a]
+            if (type === 'string') {
+              str += "'" + args[a] + "'"
+              lastPos = i + 2
+              i++
+              break
+            }
+            if (type === 'function') {
+              str += args[a].name || '<anonymous>'
+              lastPos = i + 2
+              i++
+              break
+            }
+            str += ss(args[a])
+            lastPos = i + 2
+            i++
+            break
+          case CHAR_s:
+            if (a >= argLen) break
+            if (lastPos < i) str += f.slice(lastPos, i)
+            str += String(args[a])
+            lastPos = i + 2
+            i++
+            break
+          case CHAR_PERCENT:
+            if (lastPos < i) str += f.slice(lastPos, i)
+            str += '%'
+            lastPos = i + 2
+            i++
+            a--
+            break
+        }
+
+        // Apply any formatters
+        if (formatters[c]) {
+          str += formatters[c](args[a])
+          lastPos = i + 2
+          i++
+        }
+
+        ++a
+      }
+      ++i
+    }
+    if (lastPos === -1) return f
+    else if (lastPos < flen) {
+      str += f.slice(lastPos)
+    }
+
+    return str
   }
 
-  return str
+  return format
 }

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,23 @@ and then escape the whole string.
 ## usage
 
 ```js
-var format = require('quick-format-unescaped')
+var format = require('quick-format-unescaped')()
 format('hello %s %j %d', ['world', [{ obj: true }, 4, { another: 'obj' }]])
+```
+
+To specify custom formatters, pass in `opt.formatters`:
+
+```js
+const build = require('quick-format-unescaped')
+const format = build({
+  formatters: {
+    // Pass in whatever % interpolator you want, as long as it's a single character;
+    // in this case, it's `t`.
+    // The formatter should be a function that takes in a value and returns the formatted value.
+    t: time => new Date(time).toLocaleString()
+  }
+})
+format('hello %s at %t', ['world', Date.now()])
 ```
 
 ## format(fmt, parameters, [options])
@@ -59,19 +74,6 @@ util*100000: 286.349ms
 quick*100000: 214.646ms
 utilWithTailObj*100000: 388.574ms
 quickWithTailObj*100000: 226.036ms
-```
-
-Existing impl:
-
-```
-util*100000: 1.245s
-quick*100000: 1.212s
-utilWithTailObj*100000: 1.313s
-quickWithTailObj*100000: 1.217s
-util*100000: 1.229s
-quick*100000: 1.203s
-utilWithTailObj*100000: 1.308s
-quickWithTailObj*100000: 1.213s
 ```
 
 ## Acknowledgements

--- a/readme.md
+++ b/readme.md
@@ -2,14 +2,14 @@
 
 ## unescaped ?
 
-Sometimes you want to embed the results of quick-format into another string, 
-and then escape the whole string. 
+Sometimes you want to embed the results of quick-format into another string,
+and then escape the whole string.
 
 ## usage
 
 ```js
 var format = require('quick-format-unescaped')
-format('hello %s %j %d', ['world', [{obj: true}, 4, {another: 'obj'}]])
+format('hello %s %j %d', ['world', [{ obj: true }, 4, { another: 'obj' }]])
 ```
 
 ## format(fmt, parameters, [options])
@@ -24,14 +24,14 @@ Array of values to be inserted into the `format` string. Example: `['world', {ob
 
 ### options.stringify
 
-Passing an options object as the third parameter with a `stringify` will mean 
-any objects will be passed to the supplied function instead of an the 
+Passing an options object as the third parameter with a `stringify` will mean
+any objects will be passed to the supplied function instead of an the
 internal `tryStringify` function. This can be useful when using augmented
-capability serializers such as [`fast-safe-stringify`](http://github.com/davidmarkclements/fast-safe-stringify) or [`fast-redact`](http://github.com/davidmarkclements/fast-redact).  
+capability serializers such as [`fast-safe-stringify`](http://github.com/davidmarkclements/fast-safe-stringify) or [`fast-redact`](http://github.com/davidmarkclements/fast-redact).
 
 ## caveats
 
-By default `quick-format-unescaped` uses  `JSON.stringify` instead of `util.inspect`, this means functions *will not be serialized*.
+By default `quick-format-unescaped` uses `JSON.stringify` instead of `util.inspect`, this means functions _will not be serialized_.
 
 ## Benchmarks
 
@@ -59,6 +59,19 @@ util*100000: 286.349ms
 quick*100000: 214.646ms
 utilWithTailObj*100000: 388.574ms
 quickWithTailObj*100000: 226.036ms
+```
+
+Existing impl:
+
+```
+util*100000: 1.245s
+quick*100000: 1.212s
+utilWithTailObj*100000: 1.313s
+quickWithTailObj*100000: 1.217s
+util*100000: 1.229s
+quick*100000: 1.203s
+utilWithTailObj*100000: 1.308s
+quickWithTailObj*100000: 1.213s
 ```
 
 ## Acknowledgements

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
-'use strict';
-const assert = require('assert');
-const format = require('../');
+'use strict'
+const assert = require('assert')
+const build = require('../')
+const format = build()
 
 // assert.equal(format([]), '');
 // assert.equal(format(['']), '');
@@ -21,74 +22,79 @@ assert.equal(format('', ['a']), '')
 
 // ES6 Symbol handling
 const symbol = Symbol('foo')
-assert.equal(format(null, [symbol]), null);
-assert.equal(format('foo', [symbol]), 'foo');
-assert.equal(format('%s', [symbol]), 'Symbol(foo)');
-assert.equal(format('%j', [symbol]), 'undefined');
-assert.throws(function() {
-  format('%d', [symbol]);
-}, TypeError);
+assert.equal(format(null, [symbol]), null)
+assert.equal(format('foo', [symbol]), 'foo')
+assert.equal(format('%s', [symbol]), 'Symbol(foo)')
+assert.equal(format('%j', [symbol]), 'undefined')
+assert.throws(function () {
+  format('%d', [symbol])
+}, TypeError)
 
-assert.equal(format('%d', [42.0]), '42');
-assert.equal(format('%d', [42]), '42');
-assert.equal(format('%f', [42.99]), '42.99');
-assert.equal(format('%i', [42.99]), '42');
-assert.equal(format('%s', [42]), '42');
-assert.equal(format('%j', [42]), '42');
+assert.equal(format('%d', [42.0]), '42')
+assert.equal(format('%d', [42]), '42')
+assert.equal(format('%f', [42.99]), '42.99')
+assert.equal(format('%i', [42.99]), '42')
+assert.equal(format('%s', [42]), '42')
+assert.equal(format('%j', [42]), '42')
 
-assert.equal(format('%d', [undefined]), '%d');
-assert.equal(format('%s', [undefined]), 'undefined');
-assert.equal(format('%j', [undefined]), '%j');
+assert.equal(format('%d', [undefined]), '%d')
+assert.equal(format('%s', [undefined]), 'undefined')
+assert.equal(format('%j', [undefined]), '%j')
 
+assert.equal(format('%d', [null]), '%d')
+assert.equal(format('%i', [null]), '%i')
+assert.equal(format('%s', [null]), 'null')
+assert.equal(format('%j', [null]), 'null')
 
-assert.equal(format('%d', [null]), '%d');
-assert.equal(format('%i', [null]), '%i');
-assert.equal(format('%s', [null]), 'null');
-assert.equal(format('%j', [null]), 'null');
-
-
-assert.equal(format('%d', ['42.0']), '42');
-assert.equal(format('%d', ['42']), '42');
-assert.equal(format('%i', ['42']), '42');
-assert.equal(format('%i', ['42.99']), '42');
-assert.equal(format('%s %i', ['foo', 42.99]), 'foo 42');
-assert.equal(format('%d %d', ['42']), '42 %d');
-assert.equal(format('%i %i', ['42']), '42 %i');
-assert.equal(format('%i %i', ['42.99']), '42 %i');
-assert.equal(format('foo %d', ['42']), 'foo 42');
-assert.equal(format('%s', ['42']), '42');
+assert.equal(format('%d', ['42.0']), '42')
+assert.equal(format('%d', ['42']), '42')
+assert.equal(format('%i', ['42']), '42')
+assert.equal(format('%i', ['42.99']), '42')
+assert.equal(format('%s %i', ['foo', 42.99]), 'foo 42')
+assert.equal(format('%d %d', ['42']), '42 %d')
+assert.equal(format('%i %i', ['42']), '42 %i')
+assert.equal(format('%i %i', ['42.99']), '42 %i')
+assert.equal(format('foo %d', ['42']), 'foo 42')
+assert.equal(format('%s', ['42']), '42')
 // assert.equal(format('%j', ['42']), '"42"');
 
 // assert.equal(format('%%s%s', ['foo']), '%sfoo');
 
-assert.equal(format('%s', []), '%s');
-assert.equal(format('%s', [undefined]), 'undefined');
-assert.equal(format('%s', ['foo']), 'foo');
-assert.equal(format('%s', ['\"quoted\"']), '\"quoted\"');
-assert.equal(format('%j', [{ s: '\"quoted\"' }]), '{\"s\":\"\\"quoted\\"\"}');
-assert.equal(format('%s:%s', []), '%s:%s');
-assert.equal(format('%s:%s', [undefined]), 'undefined:%s');
-assert.equal(format('%s:%s', ['foo']), 'foo:%s');
-assert.equal(format('%s:%s', ['foo', 'bar']), 'foo:bar');
-assert.equal(format('%s:%s', ['foo', 'bar', 'baz']), 'foo:bar');
-assert.equal(format('%s%s', []), '%s%s');
-assert.equal(format('%s%s', [undefined]), 'undefined%s');
-assert.equal(format('%s%s', ['foo']), 'foo%s');
-assert.equal(format('%s%s', ['foo', 'bar']), 'foobar');
-assert.equal(format('%s%s', ['foo', 'bar', 'baz']), 'foobar');
+assert.equal(format('%s', []), '%s')
+assert.equal(format('%s', [undefined]), 'undefined')
+assert.equal(format('%s', ['foo']), 'foo')
+assert.equal(format('%s', ['"quoted"']), '"quoted"')
+assert.equal(format('%j', [{ s: '"quoted"' }]), '{"s":"\\"quoted\\""}')
+assert.equal(format('%s:%s', []), '%s:%s')
+assert.equal(format('%s:%s', [undefined]), 'undefined:%s')
+assert.equal(format('%s:%s', ['foo']), 'foo:%s')
+assert.equal(format('%s:%s', ['foo', 'bar']), 'foo:bar')
+assert.equal(format('%s:%s', ['foo', 'bar', 'baz']), 'foo:bar')
+assert.equal(format('%s%s', []), '%s%s')
+assert.equal(format('%s%s', [undefined]), 'undefined%s')
+assert.equal(format('%s%s', ['foo']), 'foo%s')
+assert.equal(format('%s%s', ['foo', 'bar']), 'foobar')
+assert.equal(format('%s%s', ['foo', 'bar', 'baz']), 'foobar')
 
 assert.equal(format('foo %s', ['foo']), 'foo foo')
 
-assert.equal(format('foo %o', [{foo: 'foo'}]), 'foo {"foo":"foo"}')
-assert.equal(format('foo %O', [{foo: 'foo'}]), 'foo {"foo":"foo"}')
-assert.equal(format('foo %j', [{foo: 'foo'}]), 'foo {"foo":"foo"}')
-assert.equal(format('foo %j %j', [{foo: 'foo'}]), 'foo {"foo":"foo"} %j')
-assert.equal(format('foo %j', ['foo']), 'foo \'foo\'') // TODO: isn't this wrong?
-assert.equal(format('foo %j', [function foo () {}]), 'foo foo')
+assert.equal(format('foo %o', [{ foo: 'foo' }]), 'foo {"foo":"foo"}')
+assert.equal(format('foo %O', [{ foo: 'foo' }]), 'foo {"foo":"foo"}')
+assert.equal(format('foo %j', [{ foo: 'foo' }]), 'foo {"foo":"foo"}')
+assert.equal(format('foo %j %j', [{ foo: 'foo' }]), 'foo {"foo":"foo"} %j')
+assert.equal(format('foo %j', ['foo']), "foo 'foo'") // TODO: isn't this wrong?
+assert.equal(format('foo %j', [function foo() {}]), 'foo foo')
 assert.equal(format('foo %j', [function () {}]), 'foo <anonymous>')
-assert.equal(format('foo %j', [{foo: 'foo'}, 'not-printed']), 'foo {"foo":"foo"}')
 assert.equal(
-  format('foo %j', [{ foo: 'foo' }], { stringify () { return 'REPLACED' } }),
+  format('foo %j', [{ foo: 'foo' }, 'not-printed']),
+  'foo {"foo":"foo"}'
+)
+assert.equal(
+  format('foo %j', [{ foo: 'foo' }], {
+    stringify() {
+      return 'REPLACED'
+    }
+  }),
   'foo REPLACED'
 )
 const circularObject = {}
@@ -131,6 +137,18 @@ assert.equal(format('%d%s', [11, 22]), '1122')
 assert.equal(format('%d%o', [11, { aa: 22 }]), '11{"aa":22}')
 assert.equal(format('%d%d%d', [11, 22, 33]), '112233')
 assert.equal(format('%d%d%s', [11, 22, 33]), '112233')
-assert.equal(format('%d%o%d%s', [11, { aa: 22 }, 33, 'sss']), '11{"aa":22}33sss')
+assert.equal(
+  format('%d%o%d%s', [11, { aa: 22 }, 33, 'sss']),
+  '11{"aa":22}33sss'
+)
 assert.equal(format('%d%%%d', [11, 22]), '11%22')
 assert.equal(format('%d%%%s', [11, 22]), '11%22')
+
+const customFormatter = build({
+  formatters: { t: ms => new Date(ms).toISOString() }
+})
+const now = Date.now()
+assert.equal(
+  customFormatter('%s%t%s', ['[', now, ']']),
+  `[${new Date(now).toISOString()}]`
+)

--- a/test/index.js
+++ b/test/index.js
@@ -144,6 +144,9 @@ assert.equal(
 assert.equal(format('%d%%%d', [11, 22]), '11%22')
 assert.equal(format('%d%%%s', [11, 22]), '11%22')
 
+assert.throws(() => build({ formatters: { haha: () => 'Jonathan' } }))
+assert.throws(() => build({ formatters: { t: 'Jonathan' } }))
+
 const customFormatter = build({
   formatters: { t: ms => new Date(ms).toISOString() }
 })


### PR DESCRIPTION
See https://github.com/pinojs/pino/issues/1376

Changes:
- instead of a default `format` function, export a _builder_ for the format function instead (this is the breaking bit, and is needed to make this library configurable; I was not able to get it to work using the trick mentioned in the other thread)
- take in a custom `formatters` opt and run interpolation with it (the actual feature bit)
- using predefined consts instead of using magic numbers (please feel free to revert this should you feel the need to)
- tons of code formatting, I'm really sorry about this, I was too weak to stop vscode/prettier